### PR TITLE
Wildcard subscription (#,+). Wildcard subscription tests.

### DIFF
--- a/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
+++ b/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
@@ -134,7 +134,26 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
 
   whenUnhandled {
     case Event(msg: Message, _) =>
-      context.child(urlEnc(msg.topic)) foreach (_ ! msg)
+      val topicArr = msg.topic.split("/")
+
+      context.children.filter { c =>
+        val nameArr = urlDec(c.path.name).split("/")
+
+        nameArr.last match {
+          case "#" =>
+            topicArr.zip(nameArr.dropRight(1)).forall {
+              case (t, n) => t == n || n == "+"
+            }
+
+          case _ =>
+
+            topicArr.length == nameArr.length &&
+              topicArr.zip(nameArr).forall {
+                case (t, n) => t == n || n == "+"
+              }
+        }
+      }.foreach(_ ! msg)
+
       stay()
 
     case Event(UnderlyingSubsAck(topic, fail), _) =>


### PR DESCRIPTION
\+ and # implemented according to:

https://www.eclipse.org/paho/files/mqttdoc/Cclient/wildcard.html
