### PR TITLE
Connect callback

### DIFF
--- a/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
+++ b/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
@@ -200,6 +200,7 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
   override def postStop(): Unit = {
     super.postStop()
     disconnectedCallback
+    client.disconnectForcibly()
   }
 
   def disconnectedCallback(): Unit = {

--- a/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
+++ b/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
@@ -86,6 +86,7 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
       if (cfg.stashTimeToLive.isFinite())
         pubStash.dequeueAll(_._1 + cfg.stashTimeToLive.toNanos < System.nanoTime)
       while (pubStash.nonEmpty) self ! pubStash.dequeue()._2
+      connectedCallback
       goto(ConnectedState)
 
     case Event(x: Publish, _) =>
@@ -194,6 +195,19 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
     val delay = cfg.connectDelay(connectCount)
     logger.info(s"delay $delay before reconnect")
     setTimer("reconnect", Connect, delay)
+  }
+
+  override def postStop(): Unit = {
+    super.postStop()
+    disconnectedCallback
+  }
+
+  def disconnectedCallback(): Unit = {
+    // empty -- subclasses can implement
+  }
+
+  def connectedCallback(): Unit = {
+    // empty -- subclasses can implement
   }
 
   initialize()


### PR DESCRIPTION
Provides callback methods on the PubSub actor that can be overridden to provide additional functionality. My employer's corporate standard requires status messages after connection and before disconnection; this would support that requirement.
