### PR TITLE
Added configurable client id; if null it will generate random ID

### DIFF
--- a/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
+++ b/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
@@ -23,7 +23,7 @@ object MqttPubSub {
 class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
   //setup MqttAsyncClient without MqttClientPersistence
   private[this] val client = {
-    val c = new MqttAsyncClient(cfg.brokerUrl, MqttAsyncClient.generateClientId(), null)
+    val c = new MqttAsyncClient(cfg.brokerUrl, determineClientId(cfg), null)
     c.setCallback(new PubSubMqttCallback(self))
     c
   }
@@ -194,6 +194,13 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
     val delay = cfg.connectDelay(connectCount)
     logger.info(s"delay $delay before reconnect")
     setTimer("reconnect", Connect, delay)
+  }
+
+  private def determineClientId(cfg: PSConfig): String = {
+    if (cfg.clientId == null || cfg.clientId.isEmpty) {
+      return MqttAsyncClient.generateClientId()
+    }
+    cfg.clientId
   }
 
   initialize()

--- a/src/main/scala/com/sandinh/paho/akka/PSConfig.scala
+++ b/src/main/scala/com/sandinh/paho/akka/PSConfig.scala
@@ -21,6 +21,7 @@ case class PSConfig(
     brokerUrl:         String,
     userName:          String         = null,
     password:          String         = null,
+    clientId:          String         = null,
     stashTimeToLive:   Duration       = 1.minute,
     stashCapacity:     Int            = 8000,
     reconnectDelayMin: FiniteDuration = 10.millis,


### PR DESCRIPTION
We're required to use specified client IDs; this change allows one to be specified in the PSConfig. If left null, the code falls back to a generated ID.
